### PR TITLE
Add Russian language support and refresh bot messaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY . .
 
 # 6. Compile translation files
 RUN msgfmt locale/pt_BR/LC_MESSAGES/pt_BR.po -o locale/pt_BR/LC_MESSAGES/helpdeskbot.mo
+RUN msgfmt locale/ru_RU/LC_MESSAGES/ru_RU.po -o locale/ru_RU/LC_MESSAGES/helpdeskbot.mo
 
 # 7. Command to run the application
 CMD ["python", "-c", "from main import updater; updater.start_polling()"]

--- a/config.py
+++ b/config.py
@@ -34,7 +34,3 @@ REDIS_PORT: int = _optional_int("REDIS_PORT", 6379)
 REDIS_DB: int = _optional_int("REDIS_DB", 0)
 
 START_MESSAGE: Optional[str] = _optional_str("START_MESSAGE")
-REPLY_MESSAGE: str = _optional_str(
-    "REPLY_MESSAGE",
-    "Give me some time to think. Soon I will return to you with an answer.",
-) or "Give me some time to think. Soon I will return to you with an answer."

--- a/locale/pt_BR/LC_MESSAGES/pt_BR.po
+++ b/locale/pt_BR/LC_MESSAGES/pt_BR.po
@@ -16,59 +16,39 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: main.py\n"
 
-#: main.py:57
-msgid "Hello!\n"
-msgstr "Olá!\n"
-
-#: main.py:58
+#: main.py:53
 #, python-brace-format
-msgid "I'm {0} and I came here to help you.\n"
-msgstr "Eu sou {0} e vim aqui para te ajudar.\n"
-
-#: main.py:59
-msgid ""
-"What would you like to do?\n"
-"\n"
-msgstr ""
-"O que você gostaria de fazer?\n"
-"\n"
-
-#: main.py:60
-msgid "/support - Opens a new support ticket\n"
-msgstr "/support - Abre um novo ticket de suporte\n"
+msgid "Hey there! I'm {0}, your friendly support bot.\n\nReady to help. What's up?\n"
+msgstr "Oi! Eu sou {0}, seu bot de suporte super amigo.\n\nPronto para ajudar. O que manda?\n"
 
 #: main.py:61
-msgid ""
-"/settings - Settings of your account\n"
-"\n"
-msgstr ""
-"/settings - Configurações da sua conta\n"
-"\n"
+msgid "/support - Get help\n"
+msgstr "/support - Obter ajuda\n"
 
-#: main.py:82
-msgid "Please, tell me what you need support with :)"
-msgstr "Por favor, me diga com o que você precisa de suporte :)"
+#: main.py:62
+msgid "/settings - Change language\n"
+msgstr "/settings - Mudar idioma\n"
 
-#: main.py:107
-msgid "Give me some time to think. Soon I will return to you with an answer."
-msgstr "Me dê um tempo para pensar. Em breve eu irei retornar com uma resposta."
+#: main.py:83
+msgid "Go for it! Just type your question or issue below."
+msgstr "Manda ver! É só digitar sua dúvida ou problema aqui embaixo."
 
-#: main.py:116
-msgid "Please, choose a language:\n"
-msgstr "Por favor, escolha uma linguagem:\n"
+#: main.py:112
+msgid "Pick your language:\n"
+msgstr "Escolha seu idioma:\n"
 
-#: main.py:152
+#: main.py:146
 #, python-brace-format
-msgid "Language updated to {0}"
-msgstr "Linguagem atualizada para {0}"
+msgid "All set! We'll chat in {0} from now on."
+msgstr "Tudo certo! Vamos conversar em {0} a partir de agora."
+
+#: main.py:149
+msgid "Hmm, I don't recognize that language. Please pick from the list."
+msgstr "Hmm, não reconheço esse idioma. Por favor, escolha na lista."
 
 #: main.py:157
-msgid "Unknown language! :("
-msgstr "Linguagem desconhecida! :("
-
-#: main.py:165
-msgid "Sorry, I don't know what you're asking for."
-msgstr "Desculpe, eu não sei o que você está pedindo."
+msgid "Oops, not sure what that command does. Try /support or /settings."
+msgstr "Ops, não sei o que esse comando faz. Tente /support ou /settings."
 
 #~ msgid "I'm Via Livre Bot and I came here to help you.\n"
 #~ msgstr "Eu sou o Via Livre Bot e vim aqui para te ajudar.\n"

--- a/locale/ru_RU/LC_MESSAGES/ru_RU.po
+++ b/locale/ru_RU/LC_MESSAGES/ru_RU.po
@@ -1,0 +1,31 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: helpdeskbot\n"
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Hey there! I'm {0}, your friendly support bot.\n\nReady to help. What's up?\n"
+msgstr "Привет! Я {0}, твой дружелюбный бот поддержки.\n\nГотов помочь. Что случилось?\n"
+
+msgid "/support - Get help\n"
+msgstr "/support - Получить помощь\n"
+
+msgid "/settings - Change language\n"
+msgstr "/settings - Сменить язык\n"
+
+msgid "Go for it! Just type your question or issue below."
+msgstr "Действуй! Просто напиши свой вопрос или проблему ниже."
+
+msgid "Pick your language:\n"
+msgstr "Выбери язык:\n"
+
+msgid "All set! We'll chat in {0} from now on."
+msgstr "Готово! Теперь будем общаться на {0}."
+
+msgid "Hmm, I don't recognize that language. Please pick from the list."
+msgstr "Хм, я не знаю такой язык. Пожалуйста, выбери из списка."
+
+msgid "Oops, not sure what that command does. Try /support or /settings."
+msgstr "Ой, не знаю такой команды. Попробуй /support или /settings."


### PR DESCRIPTION
## Summary
- add a Russian locale and load it in the bot, including the language picker UI
- refresh the English copy to a friendlier tone and update existing Portuguese translations
- remove the automatic support confirmation message and compile the new locale in the Docker image

## Testing
- python -m compileall main.py
- msgfmt locale/pt_BR/LC_MESSAGES/pt_BR.po -o /tmp/pt_BR.mo
- msgfmt locale/ru_RU/LC_MESSAGES/ru_RU.po -o /tmp/ru_RU.mo

------
https://chatgpt.com/codex/tasks/task_e_68e6a6487fd0832f9d6c584767a98123